### PR TITLE
fix: change how image is loaded

### DIFF
--- a/src/main/java/adv1b/group06/kakeibo/OCRTool.java
+++ b/src/main/java/adv1b/group06/kakeibo/OCRTool.java
@@ -29,8 +29,7 @@ public class OCRTool {
 
     public OCRTool() {
         resPath = Objects.requireNonNull(this.getClass().getResource("")).toString();
-        resPath = resPath.substring(resPath.indexOf(':') + 1);
-
+        resPath = resPath.substring(resPath.indexOf(':') + 2);
         instance = new Tesseract();
         instance.setVariable("user_defined_dpi", "300");
         instance.setDatapath(resPath + "traineddata");

--- a/src/main/java/adv1b/group06/kakeibo/WordCategorize.java
+++ b/src/main/java/adv1b/group06/kakeibo/WordCategorize.java
@@ -18,7 +18,7 @@ import java.util.List;
  * @author 須藤
  */
 public class WordCategorize {
-    private static String key;
+    private static String key = "";
 
     /**
      * OpenAIのAPI keyのsetter
@@ -36,6 +36,10 @@ public class WordCategorize {
      * @return カテゴリ
      */
     public static Category fetchCategory(String item) {
+        if (key == null || key.equals("")) {
+            System.out.println("No API key");
+            return Category.getUnassignedCategory();
+        }
         try {
             // APIエンドポイントのURLを指定
             URL url = new URI("https://api.openai.com/v1/chat/completions").toURL();

--- a/src/main/java/adv1b/group06/kakeibo/controller/ItemAddController.java
+++ b/src/main/java/adv1b/group06/kakeibo/controller/ItemAddController.java
@@ -25,6 +25,7 @@ import javafx.stage.Stage;
 import javafx.util.Pair;
 import net.sourceforge.tess4j.TesseractException;
 
+import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -103,8 +104,7 @@ public class ItemAddController {
         if (selectedFile == null) {
             return;
         }
-        Image image = new Image(selectedFile.toURI().toString());
-        BufferedImage img = SwingFXUtils.fromFXImage(image, null);
+        BufferedImage img = ImageIO.read(selectedFile);
         OCRTool ocrTool = new OCRTool();
         List<Pair<String, Integer>> items = ocrTool.getDataFromBufferedImage(img);
         for (Pair<String, Integer> item : items) {


### PR DESCRIPTION
ファイルがうまく読み込めていなかったためファイルの読み込み方法を変更
また，traindataの読み込み時にうまく読めていなかった問題も修正
このtraindataの読み込みのpath編集が私の環境では動かなかったため+1から+2に変更した
もし環境依存の場合，読み込み方法を変える必要あり